### PR TITLE
Changed the name of the vlan struct

### DIFF
--- a/include/dnet/eth.h
+++ b/include/dnet/eth.h
@@ -52,7 +52,7 @@ struct eth_hdr {
 #define ETH_TYPE_8021ad_2	0x9200	/* CISCO double tagging */
 #define ETH_TYPE_8021ad_3	0x9300	/* CISCO double tagging */
 
-struct eth_vlan_hdr {
+struct eth_8021q_hdr {
 	uint16_t	priority_c_vid;	/* priority | VLAN ID, or Tag Control ID (TCI) */
 	uint16_t	len_eth_type;	/* length or type (802.3 / Eth 2) */
 };


### PR DESCRIPTION
Changed the name of `struct eth_vlan_hdr` in _eth.h_ to `struct eth_8021q_hdr` in order to help prevent name collision with other popular networking libraries, such as pf_ring.

Since this struct has been recently added to libdnet, I elect to change it here.
