### PR TITLE
Resync with the nmap changes to libdnet

### DIFF
--- a/include/dnet/arp.h
+++ b/include/dnet/arp.h
@@ -42,6 +42,7 @@ struct arp_hdr {
 #define ARP_HRD_INFINIBAND 0x0020 /* InfiniBand */
 #define ARP_HRD_APPLETALK 0x0309 /* AppleTalk DDP */
 #define ARP_HDR_IEEE80211 0x0321  /* IEEE 802.11 */
+#define ARP_HRD_IEEE80211_PRISM 0x0322  /* IEEE 802.11 + prism header */
 #define ARP_HRD_IEEE80211_RADIOTAP 0x0323  /* IEEE 802.11 + radiotap header */
 #define ARP_HRD_VOID 0xFFFF			/* Void type, nothing is known */
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,3 +9,5 @@ libdnet_la_SOURCES = addr-util.c addr.c blob.c ip-util.c ip6.c rand.c
 libdnet_la_LIBADD = @LTLIBOBJS@
 
 libdnet_la_LDFLAGS = -version-info 1:1:0
+
+noinst_HEADERS = crc32ct.h

--- a/src/addr.c
+++ b/src/addr.c
@@ -343,6 +343,7 @@ addr_ston(const struct sockaddr *sa, struct addr *a)
 	case ARP_HRD_APPLETALK: /* AppleTalk DDP */
 	case ARP_HRD_INFINIBAND: /* InfiniBand */
 	case ARP_HDR_IEEE80211: /* IEEE 802.11 */
+	case ARP_HRD_IEEE80211_PRISM: /* IEEE 802.11 + prism header */
 	case ARP_HRD_IEEE80211_RADIOTAP: /* IEEE 802.11 + radiotap header */
 #endif
 		a->addr_type = ADDR_TYPE_ETH;

--- a/src/intf.c
+++ b/src/intf.c
@@ -20,6 +20,10 @@
 # include <sys/sockio.h>
 #endif
 /* XXX - AIX */
+#ifdef HAVE_GETKERNINFO
+#include <sys/ndd_var.h>
+#include <sys/kinfo.h>
+#endif
 #ifndef IP_MULTICAST
 # define IP_MULTICAST
 #endif
@@ -477,6 +481,11 @@ static int
 _intf_get_noalias(intf_t *intf, struct intf_entry *entry)
 {
 	struct ifreq ifr;
+#ifdef HAVE_GETKERNINFO
+  int size;
+  struct kinfo_ndd *nddp;
+  void *end;
+#endif
 
 	/* Get interface index. */
 	entry->intf_index = if_nametoindex(entry->intf_name);
@@ -517,7 +526,39 @@ _intf_get_noalias(intf_t *intf, struct intf_entry *entry)
 				return (-1);
 		}
 	} else if (entry->intf_type == INTF_TYPE_ETH) {
-#if defined(SIOCGIFHWADDR)
+#if defined(HAVE_GETKERNINFO)
+	  /* AIX also defines SIOCGIFHWADDR, but it fails silently?
+	   * This is the method IBM recommends here:
+	   * http://www-01.ibm.com/support/knowledgecenter/ssw_aix_53/com.ibm.aix.progcomm/doc/progcomc/skt_sndother_ex.htm%23ssqinc2joyc?lang=en
+	   */
+	  /* How many bytes will be returned? */
+    size = getkerninfo(KINFO_NDD, 0, 0, 0);
+    if (size <= 0) {
+      return -1;
+    }
+    nddp = (struct kinfo_ndd *)malloc(size);
+
+    if (!nddp) {
+      return -1;
+    }
+    /* Get all Network Device Driver (NDD) info */
+    if (getkerninfo(KINFO_NDD, nddp, &size, 0) < 0) {
+      free(nddp);
+      return -1;
+    }
+    /* Loop over the returned values until we find a match */
+    end = (void *)nddp + size;
+    while ((void *)nddp < end) {
+      if (!strcmp(nddp->ndd_alias, entry->intf_name) ||
+          !strcmp(nddp->ndd_name, entry->intf_name)) {
+        addr_pack(&entry->intf_link_addr, ADDR_TYPE_ETH, ETH_ADDR_BITS,
+            nddp->ndd_addr, ETH_ADDR_LEN);
+        break;
+      } else
+        nddp++;
+    }
+    free(nddp);
+#elif defined(SIOCGIFHWADDR)
 		if (ioctl(intf->fd, SIOCGIFHWADDR, &ifr) < 0)
 			return (-1);
 		if (addr_ston(&ifr.ifr_addr, &entry->intf_link_addr) < 0)

--- a/src/route-bsd.c
+++ b/src/route-bsd.c
@@ -61,7 +61,7 @@ http://www.opensource.apple.com/source/network_cmds/network_cmds-329.2.2/netstat
 #define RT_MSGHDR_ALIGNMENT sizeof(unsigned long)
 #endif
 
-#ifdef RT_ROUNDUP
+#if defined(RT_ROUNDUP) && defined(__NetBSD__)
 /* NetBSD defines this macro rounding to 64-bit boundaries.
    http://fxr.watson.org/fxr/ident?v=NETBSD;i=RT_ROUNDUP */
 #define ROUNDUP(a) RT_ROUNDUP(a)


### PR DESCRIPTION
I noticed that nmap has applied a few fixes to their copy since we forked libdnet. This adds the relevant patches from their copy.